### PR TITLE
Revert date of execution of archive aggregates

### DIFF
--- a/crontab
+++ b/crontab
@@ -24,9 +24,9 @@ PATH=/app/bin:/usr/bin:/bin
 0	3	*	*	*	root	python manage.py fill_monthly_link_aggregates
 10	3	*	*	*	root	python manage.py fill_monthly_user_aggregates
 50	3	*	*	*	root	python manage.py fill_monthly_pageproject_aggregates
-0	5	16	*	*	root	python manage.py archive_link_aggregates dump
-10	5	16	*	*	root	python manage.py archive_user_aggregates dump
-20	5	16	*	*	root	python manage.py archive_pageproject_aggregates dump
+0	5	10	*	*	root	python manage.py archive_link_aggregates dump
+10	5	10	*	*	root	python manage.py archive_user_aggregates dump
+20	5	10	*	*	root	python manage.py archive_pageproject_aggregates dump
 # from extlinks/links/cron.py
 # weekly
 10	5	*	*	1	root	python manage.py linksearchtotal_collect


### PR DESCRIPTION
## Description
Reverted the execution date of archive aggregates from the 16th to the 10th

## Rationale
We don't want to wait more than half a month to archive aggregates.

## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
N/A

## How Has This Been Tested?
[//]: # (- Did you add tests to your changes? Did you modify tests to accommodate your changes?)
[//]: # (- Can this change be tested manually? How?)

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
