### PR TITLE
Add HTML5 meta tags, fix typo in footer

### DIFF
--- a/extlinks/templates/base.html
+++ b/extlinks/templates/base.html
@@ -3,9 +3,10 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>
-        Wikimedia External Links Tool
-    </title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>Wikimedia External Links Tool</title>
 
     <link rel="icon" type="image/png" href="{% static "favicon.ico" %}">
     <link rel="stylesheet" href="https://tools-static.wmflabs.org/cdnjs/ajax/libs/twitter-bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
@@ -35,7 +36,7 @@
 <hr/>
 <div class="footer">
     A <a href="https://meta.wikimedia.org/wiki/The_Wikipedia_Library">Wikipedia Library</a> project -
-    <a href="https://github.com/WikipediaLibrary/externallinks">Github</a> -
+    <a href="https://github.com/WikipediaLibrary/externallinks">GitHub</a> -
     <a href="https://phabricator.wikimedia.org/project/board/4082/">Phabricator</a> -
     <a href="https://meta.wikimedia.org/wiki/Wikilink_tool">Meta</a>
 </div>


### PR DESCRIPTION
These tags ensure all pages are HTML5 compliant and are responsive on mobile devices. This patch also fixes a typo in the GitHub footer link.