### PR TITLE
Wikilink The Wall Street Journal collection not showing correct data

### DIFF
--- a/extlinks/links/management/commands/linkevents_collect.py
+++ b/extlinks/links/management/commands/linkevents_collect.py
@@ -80,6 +80,9 @@ class Command(BaseCommand):
             # A tuple value sets each respective value independently.
             # https://requests.readthedocs.io/en/latest/user/advanced/#timeouts
             timeout=(3.05, 7),
+            headers={
+                "User-Agent": 'Wikilink'
+            }
         ):
             if event.event == "message":
                 try:
@@ -208,4 +211,5 @@ class Command(BaseCommand):
         )
         for url_pattern in url_patterns:
             url_pattern.link_events.add(link_event)
+            url_pattern.collections.add(this_link_collection)
             url_pattern.save()

--- a/extlinks/links/tests.py
+++ b/extlinks/links/tests.py
@@ -291,18 +291,21 @@ class LinkEventsCollectCommandTest(TestCase):
         with self.assertRaises(SystemExit):
             call_command("linkevents_collect", test=self.event_data1)
         self.assertEqual(LinkEvent.objects.count(), 1)
+        self.assertEqual("JSTOR", URLPattern.objects.first().collections.first().name)
 
     def test_management_command_proxy_urls(self):
         self.assertEqual(LinkEvent.objects.count(), 0)
         with self.assertRaises(SystemExit):
             call_command("linkevents_collect", test=self.event_data2)
         self.assertEqual(LinkEvent.objects.count(), 2)
+        self.assertEqual("JSTOR", URLPattern.objects.first().collections.first().name)
 
     def test_management_command_dates_with_micro_seconds(self):
         self.assertEqual(LinkEvent.objects.count(), 0)
         with self.assertRaises(SystemExit):
             call_command("linkevents_collect", test=self.event_data3)
         self.assertEqual(LinkEvent.objects.count(), 2)
+        self.assertEqual("JSTOR", URLPattern.objects.first().collections.first().name)
 
 class LinkEventsArchiveCommandTest(TransactionTestCase):
     def setUp(self):


### PR DESCRIPTION
Bug: T404381
Change-Id: Ia8b81b55ac65d93e217abb5c2d6e9cd6437f56ec

Add the collection to URLPattern model object collection array.

## Description
Describe your changes in detail following the [commit message guidelines]
This is needed to create the join table relationship in links_urlpattern_collections table. 

## Rationale
[//]: # (Why is this change required? What problem does it solve?)
This is needed to create the join table relationship in links_urlpattern_collections table. 


## Phabricator Ticket
[//]: # (Link to the Phabricator ticket)
https://phabricator.wikimedia.org/T404381

## How Has This Been Tested?
Added to existing unit tests and smoke tested locally. 

## Screenshots of your changes (if appropriate):
[//]: # (It can also be a GIF to prove that your changes are working)

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
