### PR TITLE
Backfill missing Wall Street Journal aggregate data

### DIFF
--- a/extlinks/aggregates/management/commands/reaggregate_link_archives.py
+++ b/extlinks/aggregates/management/commands/reaggregate_link_archives.py
@@ -286,10 +286,7 @@ class Command(BaseCommand):
                 link_event["fields"]["timestamp"]
             ).date(),
             on_user_list=link_event['fields']["on_user_list"],
-        ).exclude(day=0)[:1].all()
-        existing_pageproject_aggregate = (
-            existing_pageproject_aggregate[0] if len(existing_pageproject_aggregate) > 0 else None
-        )
+        ).exclude(day=0).first()
         if existing_pageproject_aggregate:
             if change_number == 0:
                 existing_pageproject_aggregate.total_links_removed += 1
@@ -570,7 +567,7 @@ class Command(BaseCommand):
             day=0,
             full_date=last_day_of_month,
             on_user_list=on_user_list_flag,
-        )[:1].all()
+        ).first()
         if existing_page_project_aggregate:
             existing_page_project_aggregate.total_links_added = total_added_page_project
             existing_page_project_aggregate.total_links_removed = total_removed_page_project


### PR DESCRIPTION
- Fix existing model object check to use the .first() method instead of slicing.

Bug: T404879
Change-Id: I97bbfc55162194bc970c664995b0ec8184405e10

## Description
Describe your changes in detail following the [commit message guidelines](https://www.mediawiki.org/wiki/Gerrit/Commit_message_guidelines)

This fixes the warning we saw in production where the QuerySet has no attribute save. 

## Rationale
[//]: # (Why is this change required? What problem does it solve?)

- Fixes the re-aggregation command 

## Phabricator Ticket
https://phabricator.wikimedia.org/T404879

## How Has This Been Tested?
Re-ran the command locally using December 2024 archives and saw that the warning was no longer there. 

## Screenshots of your changes (if appropriate):

<img width="1742" height="443" alt="Screenshot 2025-10-02 at 3 55 17 PM" src="https://github.com/user-attachments/assets/9e2b66db-1385-4bb4-93e3-4a0caf050cf7" />

## Types of changes
What types of changes does your code introduce? Add an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
